### PR TITLE
Update ncore modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -397,8 +397,8 @@ module.exports = function (grunt) {
 				ignorePath: /\.\.\//
 			},
 			sass: {
-				src: ['<%= yeoman.app %>/styles/main.scss']
-				// ignorePath: /(\.\.\/){1,2}bower_components\//
+				src: ['<%= yeoman.app %>/styles/main.scss'],
+				ignorePath: /\.\.\/\.\.\//
 			}
 		},
 		// Empties folders to start fresh

--- a/app/common/core/nCore.js
+++ b/app/common/core/nCore.js
@@ -1,1 +1,0 @@
-angular.module('nCore', ['nCore.nLogger', 'nCore.nMessages', 'nCore.nExceptionHandler']);

--- a/app/index.html
+++ b/app/index.html
@@ -52,6 +52,9 @@
 		<script src="bower_components/nExceptionHandler/dist/nExceptionHandler.js"></script>
 		<script src="bower_components/medium-editor/dist/js/medium-editor.js"></script>
 		<script src="bower_components/angular-medium-editor/dist/angular-medium-editor.js"></script>
+		<script src="bower_components/angular-mocks/angular-mocks.js"></script>
+		<script src="bower_components/nHttpInterceptor/dist/nHttpInterceptor.js"></script>
+		<script src="bower_components/nCore/dist/nCore.js"></script>
 		<!-- endbower -->
 		<script src="bower_components/localforage/dist/localforage.nopromises.js"></script>
 		<script src="bower_components/js-data/dist/js-data.min.js"></script>
@@ -62,7 +65,6 @@
         <!-- build:js({.tmp,app}) scripts/scripts.js -->
         <script src="config/app.js"></script>
         <script src="config/config.js"></script>
-        <script src="common/core/nCore.js"></script>
         <script src="config/environment.js"></script>
         <script src="config/run.js"></script>
         <script src="config/api_endpoints.constant.js"></script>

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -57,12 +57,12 @@
 
 // Foundation is not automatically importable by wiredep
 @import "bower_components/foundation/scss/foundation";
-@import "bower_components/nMessages/src/nMessages";
 @import "bower_components/medium-editor/src/sass/clearfix";
 @import "bower_components/medium-editor/src/sass/pop-upwards";
 @import "bower_components/medium-editor/src/sass/medium-editor";
 @import "bower_components/medium-editor/src/sass/themes/default";
-// Bower
+// bower:scss
+@import "bower_components/nMessages/dist/nMessages.scss";
 // endbower
 
 /*

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "nLogger": "*",
     "nMessages": "*",
     "nExceptionHandler": "*",
-    "angular-medium-editor": "~0.1.0"
+    "angular-medium-editor": "~0.1.0",
+    "nCore": "*"
   },
   "devDependencies": {
     "angular-mocks": "1.3.0",


### PR DESCRIPTION
Two updates:
- nCore was released as a module yesterday, so i replaced the “fake” nCore file in common/core with this one.
- Run bower update, and let wiredep manage scss imports (nMessages for now)
- Import the _nMessages.foundation.scss if you want to have some basic styling applied. (I didn’t do this yet - you decide)
