### PR TITLE
Typed-Medium-Editor

### DIFF
--- a/app/common/tmediumeditor/tmediumeditor.directive.js
+++ b/app/common/tmediumeditor/tmediumeditor.directive.js
@@ -1,0 +1,22 @@
+(function() {
+	'use strict';
+
+	angular
+		.module('tMediumEditor')
+	  	.directive('tMediumEditor', tMediumEditor);
+
+	/* @ngInject */
+	function tMediumEditor(MediumEditor) {
+		var directive = {
+            require: 'ngModel',
+			link: link,
+			restrict: 'EA'
+		};
+
+		return directive;
+
+		function link(scope, element, attrs){
+			console.log(MediumEditor);
+		};
+	};
+})();

--- a/app/common/tmediumeditor/tmediumeditor.directive.js
+++ b/app/common/tmediumeditor/tmediumeditor.directive.js
@@ -8,27 +8,49 @@
 	/* @ngInject */
 	function tMediumEditor(MediumEditor) {
 		var directive = {
-            require: 'ngModel',
+            require: ['ngModel', 'tMediumEditor'],
+			scope: { bindOptions: '=' },
 			link: link,
+			controller: controller,
 			restrict: 'EA'
 		};
 
 		return directive;
 
-		function link(scope, element, attrs, ngModel){
+		function link(scope, element, attrs, controllers){
+
+			var ngModel = controllers[0];
+			//var directiveController = controllers[1];
 
 			var options = {};
 			var placeholder = '';
 
-			// Attributes are parsed as strings, convert to object
-			if(attrs.options) {
-				options = scope.$eval(attrs.options);
-			}
-			placeholder = options.placeholder;
+			var initOptions = function() {
+				// Attributes are parsed as strings, convert to object
+				if(attrs.options) {
+					options = scope.$eval(attrs.options);
+				}
 
-			if(angular.isDefined(scope.bindOptions)) {
-				options = angular.extend(options, scope.bindOptions);
-			}
+				if(angular.isDefined(scope.bindOptions)) {
+					options = angular.extend(options, scope.bindOptions);
+				}
+				console.log(attrs.tMediumEditor)
+				if(attrs.tMediumEditor) {
+					console.log(attrs.tMediumEditor)
+					console.log(attrs.tMediumEditor.split('.'));
+
+					console.log(scope.$parent)
+
+					//attrs.tMediumEditor = new MediumEditor(element, options);
+				}
+
+				placeholder = options.placeholder;
+			};
+			initOptions();
+
+			//if(attrs.tMediumEditor) {
+			//	scope.$parent[attrs.tMediumEditor].editor = new MediumEditor(element, options);
+			//}
 
 			/*
 				This methods uses scope.$apply
@@ -41,7 +63,7 @@
 					// lacks an API method to alter placeholder after initialization
 					if (element.html() === '<p><br></p>' || element.html() === '') {
 						options.placeholder = placeholder;
-						var editor = new MediumEditor(element, options);
+						//scope.$parent[attrs.tMediumEditor].editor = new MediumEditor(element, options);
 					}
 
 					ngModel.$setViewValue(element.html());
@@ -71,7 +93,7 @@
 						options.placeholder = '';
 					}
 
-					this.editor = new MediumEditor(element, options);
+					//scope.$parent[attrs.tMediumEditor].editor = new MediumEditor(element, options);
 				}
 
 				element.html(ngModel.$isEmpty(ngModel.$viewValue) ? '' : ngModel.$viewValue);
@@ -79,6 +101,15 @@
 				if(!ngModel.$isEmpty(ngModel.$viewValue)) {
 					angular.element(element).removeClass('medium-editor-placeholder');
 				}
+			};
+
+		}
+
+		function controller() {
+			var vm = this;
+
+			vm.test = function() {
+				console.log('Test from directive controller');
 			};
 
 		}

--- a/app/common/tmediumeditor/tmediumeditor.directive.js
+++ b/app/common/tmediumeditor/tmediumeditor.directive.js
@@ -15,8 +15,72 @@
 
 		return directive;
 
-		function link(scope, element, attrs){
-			console.log(MediumEditor);
-		};
-	};
+		function link(scope, element, attrs, ngModel){
+
+			var options = {};
+			var placeholder = '';
+
+			// Attributes are parsed as strings, convert to object
+			if(attrs.options) {
+				options = scope.$eval(attrs.options);
+			}
+			placeholder = options.placeholder;
+
+			if(angular.isDefined(scope.bindOptions)) {
+				options = angular.extend(options, scope.bindOptions);
+			}
+
+			/*
+				This methods uses scope.$apply
+			 */
+			var onChange = function() {
+
+				scope.$apply(function() {
+
+					// If user cleared the whole text, we have to reset the editor because MediumEditor
+					// lacks an API method to alter placeholder after initialization
+					if (element.html() === '<p><br></p>' || element.html() === '') {
+						options.placeholder = placeholder;
+						var editor = new MediumEditor(element, options);
+					}
+
+					ngModel.$setViewValue(element.html());
+
+				});
+
+			};
+
+			/*
+				View > Model
+			 */
+			var bindEvents = ngModel.$options.updateOn;
+
+			if(ngModel.$options.updateOnDefault) {
+				bindEvents += ' input';
+			}
+
+
+			element.on(bindEvents, onChange);
+
+			/*
+				Model > View
+			 */
+			ngModel.$render = function() {
+				if(!this.editor) {
+					if(!ngModel.$isEmpty(ngModel.$viewValue)) {
+						options.placeholder = '';
+					}
+
+					this.editor = new MediumEditor(element, options);
+				}
+
+				element.html(ngModel.$isEmpty(ngModel.$viewValue) ? '' : ngModel.$viewValue);
+
+				if(!ngModel.$isEmpty(ngModel.$viewValue)) {
+					angular.element(element).removeClass('medium-editor-placeholder');
+				}
+			};
+
+		}
+	}
 })();

--- a/app/common/tmediumeditor/tmediumeditor.directive.js
+++ b/app/common/tmediumeditor/tmediumeditor.directive.js
@@ -6,10 +6,9 @@
 	  	.directive('tMediumEditor', tMediumEditor);
 
 	/* @ngInject */
-	function tMediumEditor(MediumEditor) {
+	function tMediumEditor(MediumEditor, $timeout) {
 		var directive = {
             require: ['ngModel', 'tMediumEditor'],
-			scope: { bindOptions: '=' },
 			link: link,
 			controller: controller,
 			restrict: 'EA'
@@ -19,8 +18,9 @@
 
 		function link(scope, element, attrs, controllers){
 
+			// Assign injected controllers to variables for sanity
 			var ngModel = controllers[0];
-			//var directiveController = controllers[1];
+			var directiveController = controllers[1];
 
 			var options = {};
 			var placeholder = '';
@@ -30,31 +30,24 @@
 				if(attrs.options) {
 					options = scope.$eval(attrs.options);
 				}
-
-				if(angular.isDefined(scope.bindOptions)) {
-					options = angular.extend(options, scope.bindOptions);
-				}
-				console.log(attrs.tMediumEditor)
-				if(attrs.tMediumEditor) {
-					console.log(attrs.tMediumEditor)
-					console.log(attrs.tMediumEditor.split('.'));
-
-					console.log(scope.$parent)
-
-					//attrs.tMediumEditor = new MediumEditor(element, options);
-				}
-
 				placeholder = options.placeholder;
+
+				// Create new Medium Editor instance
+				var mediumEditor = new MediumEditor(element, options);
+
+				// Attach Directive Controller methods to Medium Editor instance
+				angular.forEach(directiveController, function(val, key) {
+					mediumEditor[key] = val;
+				});
+
+				// Find the "controllerAs" path, attach the Medium Editor to it
+				// ie. given <t-medium-editor="documents.editor">,
+				// the mediumEditor instance will be attached to scope.documents.editor.
+				var scopeTree = attrs.tMediumEditor.split('.');
+				scope[scopeTree[0]][scopeTree[1]] = mediumEditor;
+
 			};
-			initOptions();
 
-			//if(attrs.tMediumEditor) {
-			//	scope.$parent[attrs.tMediumEditor].editor = new MediumEditor(element, options);
-			//}
-
-			/*
-				This methods uses scope.$apply
-			 */
 			var onChange = function() {
 
 				scope.$apply(function() {
@@ -63,7 +56,7 @@
 					// lacks an API method to alter placeholder after initialization
 					if (element.html() === '<p><br></p>' || element.html() === '') {
 						options.placeholder = placeholder;
-						//scope.$parent[attrs.tMediumEditor].editor = new MediumEditor(element, options);
+						initOptions();
 					}
 
 					ngModel.$setViewValue(element.html());
@@ -75,25 +68,27 @@
 			/*
 				View > Model
 			 */
+			// Get configured "updateOn" events
 			var bindEvents = ngModel.$options.updateOn;
-
+			// If updateOnDefault, we add the "input" event, to the events we listen to
 			if(ngModel.$options.updateOnDefault) {
 				bindEvents += ' input';
 			}
 
-
+			// Bind events
 			element.on(bindEvents, onChange);
 
 			/*
 				Model > View
 			 */
 			ngModel.$render = function() {
+				// On initial render of ngModel, if there's no mediumEditor yet - boot it up!
 				if(!this.editor) {
+					// If a value is present in the model, remove the placeholder from the mediumEditor options
 					if(!ngModel.$isEmpty(ngModel.$viewValue)) {
 						options.placeholder = '';
 					}
-
-					//scope.$parent[attrs.tMediumEditor].editor = new MediumEditor(element, options);
+					initOptions();
 				}
 
 				element.html(ngModel.$isEmpty(ngModel.$viewValue) ? '' : ngModel.$viewValue);
@@ -103,14 +98,66 @@
 				}
 			};
 
+			scope.$on('$destroy', function() {
+				element.off(bindEvents);
+			});
+
 		}
 
-		function controller() {
+
+		function controller($document, $scope, $element, $attrs) {
 			var vm = this;
 
-			vm.test = function() {
-				console.log('Test from directive controller');
+			/**
+			 * Returns the first DOM Node in the editor, or it's text.
+			 * @param stripHtml
+			 * @returns {*} DOM Node or String
+			 */
+			vm.parseTitle = function(stripHtml) {
+				return _returnFirstChildNode(stripHtml);
 			};
+
+			/**
+			 * Set focus on the editor
+			 */
+			vm.focus = function() {
+				$element.focus();
+			};
+
+			/*
+				Private methods
+			 */
+
+			/**
+			 *
+			 * @returns {*} Editor Instance
+			 * @private
+			 */
+			function _getEditor() {
+				var scopeTree = $attrs.tMediumEditor.split('.');
+				return $scope[scopeTree[0]][scopeTree[1]];
+			}
+
+			/**
+			 * Returns the first DOM Node in the editor, or it's text.
+			 * @param stripHtml
+			 * @returns {*}
+			 * @private
+			 */
+			function _returnFirstChildNode(stripHtml) {
+				var editor = _getEditor();
+				var firstChildNode = editor.elements[0].children[0];
+
+				if(!firstChildNode) {
+					return '';
+				}
+
+				if(stripHtml) {
+					return firstChildNode.textContent;
+				}
+
+				return firstChildNode;
+			}
 
 		}
 	}

--- a/app/common/tmediumeditor/tmediumeditor.medium.constant.js
+++ b/app/common/tmediumeditor/tmediumeditor.medium.constant.js
@@ -1,0 +1,8 @@
+(function() {
+	'use strict';
+
+	angular
+		.module('tMediumEditor')
+		.constant('MediumEditor', MediumEditor);
+
+})();

--- a/app/common/tmediumeditor/tmediumeditor.module.js
+++ b/app/common/tmediumeditor/tmediumeditor.module.js
@@ -1,0 +1,5 @@
+(function () {
+	'use strict';
+
+	angular.module('tMediumEditor', []);
+})();

--- a/app/config/app.js
+++ b/app/config/app.js
@@ -30,6 +30,7 @@
 			'document',
 			'documents',
 			'tdebounce',
+'tMediumEditor',
 			/* ---> Do not delete this comment (ngImports) <--- */
 		]);
 })();

--- a/app/config/app.js
+++ b/app/config/app.js
@@ -18,7 +18,6 @@
 			'ngSanitize',
 			'ngTouch',
 			'ui.router',
-			'angular-medium-editor',
 			'nCore',
 			'js-data',
 			'config',

--- a/app/index.html
+++ b/app/index.html
@@ -55,7 +55,6 @@
 		<script src="bower_components/angular-mocks/angular-mocks.js"></script>
 		<script src="bower_components/nHttpInterceptor/dist/nHttpInterceptor.js"></script>
 		<script src="bower_components/nCore/dist/nCore.js"></script>
-
 		<!-- endbower -->
 		<script src="bower_components/localforage/dist/localforage.nopromises.js"></script>
 		<script src="bower_components/js-data/dist/js-data.min.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -55,6 +55,7 @@
 		<script src="bower_components/angular-mocks/angular-mocks.js"></script>
 		<script src="bower_components/nHttpInterceptor/dist/nHttpInterceptor.js"></script>
 		<script src="bower_components/nCore/dist/nCore.js"></script>
+
 		<!-- endbower -->
 		<script src="bower_components/localforage/dist/localforage.nopromises.js"></script>
 		<script src="bower_components/js-data/dist/js-data.min.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -81,6 +81,9 @@
         <script src="modules/documents/documents.controller.js"></script>
         <script src="common/tdebounce/tdebounce.module.js"></script>
         <script src="common/tdebounce/tdebounce.directive.js"></script>
+        <script src="common/tmediumeditor/tmediumeditor.module.js"></script>
+        <script src="common/tmediumeditor/tmediumeditor.medium.constant.js"></script>
+        <script src="common/tmediumeditor/tmediumeditor.directive.js"></script>
         <!-- endbuild -->
 </body>
 </html>

--- a/app/modules/documents/documents.controller.js
+++ b/app/modules/documents/documents.controller.js
@@ -33,6 +33,13 @@
 			vm.documents = Document.filter();
 		});
 
+		$scope.$watch(function() {
+			return vm.editor;
+		}, function(newVal) {
+			console.log(newVal);
+			console.log(vm.editor)
+		});
+
 
 		/* Initiate */
 		activate();

--- a/app/modules/documents/documents.controller.js
+++ b/app/modules/documents/documents.controller.js
@@ -12,6 +12,14 @@
 
 		vm.documents = documents;
 
+		vm.editorConfig = {
+			placeholder: 'Min placeholdning',
+			buttons: [
+				'bold',
+				'italic'
+			]
+		};
+
 		/* Bind methods */
 		vm.createDocument = createDocument;
 		vm.selectDocument = selectDocument;

--- a/app/modules/documents/documents.template.html
+++ b/app/modules/documents/documents.template.html
@@ -4,6 +4,7 @@
 <div
 	medium-editor
 	placeholder="content"
+    ng-model-options="{ updateOn: 'default blur', debounce: {'default': 500, 'blur': 0} }"
 	ng-model="documents.currentDocument.content"></div>
 <button class="tiny" ng-click="documents.updateDocument(documents.currentDocument);">Save</button>
 
@@ -20,3 +21,6 @@
     <button class="tiny" ng-click="documents.destroyDocument(document);">Delete</button>
   </li>
 </ul>
+<hr/>
+<h4>Debug:</h4>
+<pre><code>{{documents.currentDocument}}</code></pre>

--- a/app/modules/documents/documents.template.html
+++ b/app/modules/documents/documents.template.html
@@ -2,7 +2,7 @@
 
 <h4>Document</h4>
 <div
-	t-medium-editor
+	t-medium-editor="documents.editor"
     options="{{documents.editorConfig}}"
     ng-model-options="{ updateOn: 'default blur'}"
 	ng-model="documents.currentDocument.content"></div>

--- a/app/modules/documents/documents.template.html
+++ b/app/modules/documents/documents.template.html
@@ -3,8 +3,8 @@
 <h4>Document</h4>
 <div
 	t-medium-editor
-	placeholder="content"
-    ng-model-options="{ updateOn: 'default blur', debounce: {'default': 500, 'blur': 0} }"
+    options="{{documents.editorConfig}}"
+    ng-model-options="{ updateOn: 'default blur'}"
 	ng-model="documents.currentDocument.content"></div>
 <button class="tiny" ng-click="documents.updateDocument(documents.currentDocument);">Save</button>
 

--- a/app/modules/documents/documents.template.html
+++ b/app/modules/documents/documents.template.html
@@ -21,6 +21,3 @@
     <button class="tiny" ng-click="documents.destroyDocument(document);">Delete</button>
   </li>
 </ul>
-<hr/>
-<h4>Debug:</h4>
-<pre><code>{{documents.currentDocument}}</code></pre>

--- a/app/modules/documents/documents.template.html
+++ b/app/modules/documents/documents.template.html
@@ -2,7 +2,7 @@
 
 <h4>Document</h4>
 <div
-	medium-editor
+	t-medium-editor
 	placeholder="content"
     ng-model-options="{ updateOn: 'default blur', debounce: {'default': 500, 'blur': 0} }"
 	ng-model="documents.currentDocument.content"></div>

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -62,7 +62,6 @@
 @import "bower_components/medium-editor/src/sass/medium-editor";
 @import "bower_components/medium-editor/src/sass/themes/default";
 // bower:scss
-@import "bower_components/nMessages/dist/nMessages.scss";
 // endbower
 
 /*

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "nExceptionHandler": "*",
     "angular-medium-editor": "~0.1.0",
     "nCore": "*"
+    "medium-editor": "~4.9.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.0",
@@ -28,6 +29,7 @@
   },
   "appPath": "app",
   "resolutions": {
-    "angular": "1.3.15"
+    "angular": "1.3.15",
+    "medium-editor": "~4.9.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "nMessages": "*",
     "nExceptionHandler": "*",
     "angular-medium-editor": "~0.1.0",
-    "nCore": "*"
+    "nCore": "*",
     "medium-editor": "~4.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Instead of using a rarely-maintained Angular module for the Medium-Editor, I took the code from that module and corrected/simplified a few things.

This implementation has two of the dreaded $timeouts in the view controller, but as far as i can tell there is no way out of this.
- Removed angular-medium-editor dependency from bower, replaced with medium-editor dependency.

The new tMediumEditor directive:
- Add methods to the directive controller to have them exposed in any view-controller automatically (see the directive controller for how easy this is)
- Added two methods: focus and parseTitle
- Implemented these methods in the documents view:
  - Create/Edit document > focus()
  - Watch currentDocument.content > parseTitle(stripHtml)

Think this was it :-)
