### PR TITLE
"Bump" Angular to 1.4 Release Candidate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,15 +2,15 @@
   "name": "typed",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "^1.3.0",
+    "angular": "master",
     "gsap": "^1.16",
     "angular-foundation": "*",
     "foundation": "*",
-    "angular-resource": "^1.3.0",
-    "angular-cookies": "^1.3.0",
-    "angular-sanitize": "^1.3.0",
-    "angular-animate": "^1.3.0",
-    "angular-touch": "^1.3.0",
+    "angular-resource": "master",
+    "angular-cookies": "master",
+    "angular-sanitize": "master",
+    "angular-animate": "master",
+    "angular-touch": "master",
     "angular-ui-router": "^0.2.10",
     "js-data": "~1.8.0",
     "localforage": "~1.2.3",
@@ -22,13 +22,11 @@
     "nCore": "*",
     "medium-editor": "~4.9.0"
   },
-  "devDependencies": {
-    "angular-mocks": "1.3.0",
-    "angular-scenario": "1.3.0"
-  },
   "appPath": "app",
   "resolutions": {
-    "angular": "1.3.15",
-    "medium-editor": "~4.9.0"
+    "medium-editor": "~4.9.0",
+    "angular-sanitize": "master",
+    "angular-animate": "master",
+    "angular": "master"
   }
 }


### PR DESCRIPTION
It’s not really a bump since we have to specifically specify that we
need to use the master branch of the Angular repository.

We might have to “bower update” our installations more often, but the
features in ng1.4 are not to be missed out on.

I also removed the dev dependencies as we dont write any tests.

geiles merges geiles
